### PR TITLE
Feat: implementing env validation file

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,4 +1,5 @@
 import { PrismaClient } from "@prisma/client";
+import { env } from "./env";
 
 declare global {
   var prisma: PrismaClient | undefined;
@@ -6,4 +7,4 @@ declare global {
 
 export const db = globalThis.prisma || new PrismaClient();
 
-if (process.env.NODE_ENV !== "production") globalThis.prisma = db;
+if (env.NODE_ENV !== "production") globalThis.prisma = db;

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,39 @@
+import z from "zod";
+
+const clientEnvSchema = z.object({
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: z.string().nonempty(),
+  NEXT_PUBLIC_CLERK_SIGN_IN_URL: z.string().nonempty(),
+  NEXT_PUBLIC_CLERK_SIGN_UP_URL: z.string().nonempty(),
+  NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL: z.string().nonempty(),
+  NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL: z.string().nonempty(),
+  NEXT_PUBLIC_UNSPLASH_ACCESS_KEY: z.string().nonempty(),
+  NODE_ENV: z.string(),
+});
+
+const serverEnvSchema = z.object({
+  CLERK_SECRET_KEY: z.string().nonempty(),
+  DATABASE_URL: z.string().nonempty(),
+  NODE_ENV: z.string(),
+});
+
+const enviroment = {
+  NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY:
+    process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY,
+  CLERK_SECRET_KEY: process.env.CLERK_SECRET_KEY,
+  NEXT_PUBLIC_CLERK_SIGN_IN_URL: process.env.NEXT_PUBLIC_CLERK_SIGN_IN_URL,
+  NEXT_PUBLIC_CLERK_SIGN_UP_URL: process.env.NEXT_PUBLIC_CLERK_SIGN_UP_URL,
+  NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL:
+    process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_IN_URL,
+  NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL:
+    process.env.NEXT_PUBLIC_CLERK_AFTER_SIGN_UP_URL,
+  DATABASE_URL: process.env.DATABASE_URL,
+  NEXT_PUBLIC_UNSPLASH_ACCESS_KEY: process.env.NEXT_PUBLIC_UNSPLASH_ACCESS_KEY,
+  NODE_ENV: process.env.NODE_ENV,
+};
+
+export const env = clientEnvSchema.parse(enviroment);
+
+// On server
+if (typeof window === "undefined") {
+  serverEnvSchema.parse(enviroment);
+}

--- a/lib/unsplash.ts
+++ b/lib/unsplash.ts
@@ -1,8 +1,9 @@
 import { createApi } from "unsplash-js";
+import { env } from "./env";
 
 export const trelloUnsplashCollectionId = "317099";
 
 export const unsplash = createApi({
-  accessKey: process.env.NEXT_PUBLIC_UNSPLASH_ACCESS_KEY!,
+  accessKey: env.NEXT_PUBLIC_UNSPLASH_ACCESS_KEY,
   fetch: fetch,
 });


### PR DESCRIPTION
    Creating an .env file that uses Zod to validate environment variables.

    The purpose of this file is to correctly type the variables and ensure no required environment variables are missing. If any are missing, a clear error is thrown for the developer.

    There are two environment schemas: one for the server and one for the client, since non-public environment variables cannot be used on the client side.