### PR TITLE
create base overview page

### DIFF
--- a/actions/update-card-assigned-to/index.ts
+++ b/actions/update-card-assigned-to/index.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { createSafeAction } from "@/lib/create-safe-action";
+import { db } from "@/lib/db";
+import AppRoutes, { buildRoute } from "@/util/appRoutes";
+import { auth } from "@clerk/nextjs/server";
+import { revalidatePath } from "next/cache";
+import { UpdateCardAssignedTo } from "./schema";
+import { InputType, ReturnType } from "./types";
+
+const handler = async (data: InputType): Promise<ReturnType> => {
+  const { userId, orgId } = await auth();
+
+  if (!userId || !orgId) {
+    return {
+      error: "Unauthorized",
+    };
+  }
+
+  const { id, boardId, assignedTo } = data;
+  let card;
+
+  try {
+    card = await db.card.update({
+      where: {
+        id,
+        list: {
+          board: { orgId },
+        },
+      },
+      data: {
+        assignedTo,
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    return { error: "Failed to update" };
+  }
+
+  revalidatePath(buildRoute(AppRoutes.BOARD_ID, { boardId: boardId }));
+  return { data: card };
+};
+
+export const updateCardAssignedTo = createSafeAction(
+  UpdateCardAssignedTo,
+  handler
+);

--- a/actions/update-card-assigned-to/schema.ts
+++ b/actions/update-card-assigned-to/schema.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const UpdateCardAssignedTo = z.object({
+  id: z.string(),
+  boardId: z.string(),
+  assignedTo: z.string(),
+});

--- a/actions/update-card-assigned-to/types.ts
+++ b/actions/update-card-assigned-to/types.ts
@@ -1,0 +1,7 @@
+import { ActionState } from "@/lib/create-safe-action";
+import { Card } from "@prisma/client";
+import { z } from "zod";
+import { UpdateCardAssignedTo } from "./schema";
+
+export type InputType = z.infer<typeof UpdateCardAssignedTo>;
+export type ReturnType = ActionState<InputType, Card>;

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/card-item.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/card-item.tsx
@@ -1,11 +1,11 @@
 "use client";
 
+import { UserAvatar } from "@/components/assigned-to-tag";
 import { Hint } from "@/components/hint";
 import { useCardModal } from "@/hooks/use-card-modal";
 import { User } from "@clerk/nextjs/server";
 import { Draggable } from "@hello-pangea/dnd";
 import { Card } from "@prisma/client";
-import Image from "next/image";
 
 interface CardItemProps {
   data: Card;
@@ -36,13 +36,7 @@ export const CardItem = ({ data, index, user }: CardItemProps) => {
                 description={`${user.firstName ?? ""} ${user.lastName ?? ""}`}
                 delayDuration={350}
               >
-                <Image
-                  src={user.imageUrl}
-                  alt={`${user.firstName} ${user.lastName} profile pic`}
-                  width={24}
-                  height={24}
-                  className="self-center rounded-lg"
-                />
+                <UserAvatar user={user} displayName={false} />
               </Hint>
             )}
           </div>

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/card-item.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/card-item.tsx
@@ -1,15 +1,19 @@
 "use client";
 
+import { Hint } from "@/components/hint";
 import { useCardModal } from "@/hooks/use-card-modal";
+import { User } from "@clerk/nextjs/server";
 import { Draggable } from "@hello-pangea/dnd";
 import { Card } from "@prisma/client";
+import Image from "next/image";
 
 interface CardItemProps {
   data: Card;
   index: number;
+  user?: User;
 }
 
-export const CardItem = ({ data, index }: CardItemProps) => {
+export const CardItem = ({ data, index, user }: CardItemProps) => {
   const cardModal = useCardModal();
 
   return (
@@ -25,7 +29,23 @@ export const CardItem = ({ data, index }: CardItemProps) => {
             cardModal.onOpen(data.id);
           }}
         >
-          {data.title}
+          <div className="flex justify-between items-center">
+            <div>{data.title}</div>
+            {user && (
+              <Hint
+                description={`${user.firstName ?? ""} ${user.lastName ?? ""}`}
+                delayDuration={350}
+              >
+                <Image
+                  src={user.imageUrl}
+                  alt={`${user.firstName} ${user.lastName} profile pic`}
+                  width={24}
+                  height={24}
+                  className="self-center rounded-lg"
+                />
+              </Hint>
+            )}
+          </div>
         </div>
       )}
     </Draggable>

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
@@ -138,7 +138,14 @@ export const ListContainer = ({ data, boardId }: ListContainerProps) => {
             className="flex gap-x-3 h-full"
           >
             {orderedData.map((list, index) => {
-              return <ListItem key={list.id} index={index} data={list} />;
+              return (
+                <ListItem
+                  key={list.id}
+                  index={index}
+                  data={list}
+                  boardId={boardId}
+                />
+              );
             })}
             {provided.placeholder}
             <ListForm />

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
@@ -13,9 +13,14 @@ import { ListItem } from "./list-item";
 interface ListContainerProps {
   data: ListWithCards[];
   boardId: string;
+  hideAddList?: boolean;
 }
 
-export const ListContainer = ({ data, boardId }: ListContainerProps) => {
+export const ListContainer = ({
+  data,
+  boardId,
+  hideAddList = false,
+}: ListContainerProps) => {
   const [orderedData, setOrderedData] = useState(data);
 
   const { execute: executeUpdateListOrder } = useAction(updateListOrder, {
@@ -122,8 +127,6 @@ export const ListContainer = ({ data, boardId }: ListContainerProps) => {
 
         setOrderedData(newOrderedData);
         executeUpdateCardOrder({ boardId, items: destinationList.cards });
-
-        // TODO: Trigger server action
       }
     }
   };
@@ -148,7 +151,7 @@ export const ListContainer = ({ data, boardId }: ListContainerProps) => {
               );
             })}
             {provided.placeholder}
-            <ListForm />
+            {!hideAddList && <ListForm />}
             <div className="flex-shrink-0 w-1" />
           </ol>
         )}

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
@@ -1,26 +1,30 @@
 "use client";
 
 import { updateCardOrder } from "@/actions/update-card-order";
+import { updateCardSprint } from "@/actions/update-card-sprint";
 import { updateListOrder } from "@/actions/update-list-order";
 import { useAction } from "@/hooks/use-action";
 import { ListWithCards } from "@/types";
 import { DragDropContext, Droppable } from "@hello-pangea/dnd";
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import { ListForm } from "./list-form";
 import { ListItem } from "./list-item";
-
 interface ListContainerProps {
   data: ListWithCards[];
   boardId: string;
   hideAddList?: boolean;
+  dragMode?: "reorder" | "changeSprint";
 }
 
 export const ListContainer = ({
   data,
   boardId,
   hideAddList = false,
+  dragMode = "reorder",
 }: ListContainerProps) => {
+  const queryClient = useQueryClient();
   const [orderedData, setOrderedData] = useState(data);
 
   const { execute: executeUpdateListOrder } = useAction(updateListOrder, {
@@ -31,7 +35,19 @@ export const ListContainer = ({
 
   const { execute: executeUpdateCardOrder } = useAction(updateCardOrder, {
     onSuccess: () => {
-      toast.success("Card reordered");
+      toast.success(
+        dragMode === "reorder" ? "Card reordered" : "Sprint updated"
+      );
+    },
+  });
+
+  const { execute: executeUpdateCardSprint } = useAction(updateCardSprint, {
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: ["card", data.id],
+      });
+
+      toast.success(`Updated card "${data.title}" to sprint "${data.sprint}`);
     },
   });
 
@@ -89,44 +105,57 @@ export const ListContainer = ({
       // Check if cards exists on the destinationList
       if (!destinationList.cards) destinationList.cards = [];
 
-      // Moving the card in the same list
-      if (source.droppableId === destination.droppableId) {
-        const reorderedCards = reorder(
-          sourceList.cards,
-          source.index,
-          destination.index
-        );
+      if (dragMode === "reorder") {
+        // Moving within the same list
+        if (source.droppableId === destination.droppableId) {
+          const reorderedCards = reorder(
+            sourceList.cards,
+            source.index,
+            destination.index
+          );
 
-        reorderedCards.forEach((card, idx) => {
-          card.order = idx;
-        });
+          reorderedCards.forEach((card, idx) => {
+            card.order = idx;
+          });
 
-        sourceList.cards = reorderedCards;
+          sourceList.cards = reorderedCards;
 
-        setOrderedData(newOrderedData);
-        executeUpdateCardOrder({ boardId, items: reorderedCards });
-        // User moves the card to another list
-      } else {
-        // Remove card From the source list
+          setOrderedData(newOrderedData);
+          executeUpdateCardOrder({ boardId, items: reorderedCards });
+          // User moves the card to another list
+        } else {
+          // Remove card From the source list
+          const [movedCard] = sourceList.cards.splice(source.index, 1);
+
+          // Assugn the new listId to the moved card
+          movedCard.listId = destination.droppableId;
+
+          // Add card to the destination list
+          destinationList.cards.splice(destination.index, 0, movedCard);
+
+          sourceList.cards.forEach((card, idx) => {
+            card.order = idx;
+          });
+
+          // Update the order for each card in the destination list
+          destinationList.cards.forEach((card, idx) => {
+            card.order = idx;
+          });
+
+          setOrderedData(newOrderedData);
+          executeUpdateCardOrder({ boardId, items: destinationList.cards });
+        }
+      } else if (dragMode === "changeSprint") {
+        // Instead of changing the order, update sprint property
         const [movedCard] = sourceList.cards.splice(source.index, 1);
 
-        // Assugn the new listId to the moved card
-        movedCard.listId = destination.droppableId;
-
-        // Add card to the destination list
-        destinationList.cards.splice(destination.index, 0, movedCard);
-
-        sourceList.cards.forEach((card, idx) => {
-          card.order = idx;
-        });
-
-        // Update the order for each card in the destination list
-        destinationList.cards.forEach((card, idx) => {
-          card.order = idx;
-        });
-
         setOrderedData(newOrderedData);
-        executeUpdateCardOrder({ boardId, items: destinationList.cards });
+
+        executeUpdateCardSprint({
+          boardId,
+          id: movedCard.id,
+          sprint: parseInt(destination.droppableId),
+        });
       }
     }
   };
@@ -140,16 +169,14 @@ export const ListContainer = ({
             ref={provided.innerRef}
             className="flex gap-x-3 h-full"
           >
-            {orderedData.map((list, index) => {
-              return (
-                <ListItem
-                  key={list.id}
-                  index={index}
-                  data={list}
-                  boardId={boardId}
-                />
-              );
-            })}
+            {orderedData.map((list, index) => (
+              <ListItem
+                key={list.id}
+                index={index}
+                data={list}
+                boardId={boardId}
+              />
+            ))}
             {provided.placeholder}
             {!hideAddList && <ListForm />}
             <div className="flex-shrink-0 w-1" />

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
@@ -15,6 +15,7 @@ interface ListContainerProps {
   data: ListWithCards[];
   boardId: string;
   hideAddList?: boolean;
+  hideAddCard?: boolean;
   dragMode?: "reorder" | "changeSprint";
 }
 
@@ -22,6 +23,7 @@ export const ListContainer = ({
   data,
   boardId,
   hideAddList = false,
+  hideAddCard = false,
   dragMode = "reorder",
 }: ListContainerProps) => {
   const queryClient = useQueryClient();
@@ -190,6 +192,8 @@ export const ListContainer = ({
                 index={index}
                 data={list}
                 boardId={boardId}
+                hideAddCard={hideAddCard}
+                isDragDisabled={dragMode === "changeSprint"}
               />
             ))}
             {provided.placeholder}

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/list-container.tsx
@@ -149,6 +149,21 @@ export const ListContainer = ({
         // Instead of changing the order, update sprint property
         const [movedCard] = sourceList.cards.splice(source.index, 1);
 
+        // Assugn the new listId to the moved card
+        movedCard.sprint = parseInt(destination.droppableId);
+
+        // Add card to the destination list
+        destinationList.cards.splice(destination.index, 0, movedCard);
+
+        sourceList.cards.forEach((card, idx) => {
+          card.order = idx;
+        });
+
+        // Update the order for each card in the destination list
+        destinationList.cards.forEach((card, idx) => {
+          card.order = idx;
+        });
+
         setOrderedData(newOrderedData);
 
         executeUpdateCardSprint({

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/list-item.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/list-item.tsx
@@ -16,9 +16,15 @@ interface ListItemProps {
   data: ListWithCards;
   index: number;
   boardId: string;
+  hideAvatar?: boolean;
 }
 
-export const ListItem = ({ data, boardId, index }: ListItemProps) => {
+export const ListItem = ({
+  data,
+  boardId,
+  index,
+  hideAvatar = false,
+}: ListItemProps) => {
   const textareaRef = useRef<ElementRef<"textarea">>(null);
   const { data: usersFromOrg } = useQuery<User[]>({
     queryKey: ["organization", boardId],
@@ -62,9 +68,11 @@ export const ListItem = ({ data, boardId, index }: ListItemProps) => {
                   )}
                 >
                   {data.cards.map((card, index) => {
-                    const assignedUser = usersFromOrg?.find(
-                      (user) => user.id === card.assignedTo
-                    );
+                    const assignedUser = hideAvatar
+                      ? undefined
+                      : usersFromOrg?.find(
+                          (user) => user.id === card.assignedTo
+                        );
                     return (
                       <CardItem
                         key={card.id}

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/list-item.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/list-item.tsx
@@ -17,6 +17,8 @@ interface ListItemProps {
   index: number;
   boardId: string;
   hideAvatar?: boolean;
+  isDragDisabled?: boolean;
+  hideAddCard?: boolean;
 }
 
 export const ListItem = ({
@@ -24,6 +26,8 @@ export const ListItem = ({
   boardId,
   index,
   hideAvatar = false,
+  isDragDisabled = false,
+  hideAddCard = false,
 }: ListItemProps) => {
   const textareaRef = useRef<ElementRef<"textarea">>(null);
   const { data: usersFromOrg } = useQuery<User[]>({
@@ -45,7 +49,11 @@ export const ListItem = ({
   };
 
   return (
-    <Draggable draggableId={data.id} index={index}>
+    <Draggable
+      draggableId={data.id}
+      index={index}
+      isDragDisabled={isDragDisabled}
+    >
       {(provided) => (
         <li
           {...provided.draggableProps}
@@ -86,13 +94,15 @@ export const ListItem = ({
                 </ol>
               )}
             </Droppable>
-            <CardForm
-              listId={data.id}
-              ref={textareaRef}
-              isEditing={isEditing}
-              enableEditing={enableEditing}
-              disableEditing={disableEditing}
-            />
+            {!hideAddCard && (
+              <CardForm
+                listId={data.id}
+                ref={textareaRef}
+                isEditing={isEditing}
+                enableEditing={enableEditing}
+                disableEditing={disableEditing}
+              />
+            )}
           </div>
         </li>
       )}

--- a/app/(platform)/(dashboard)/board/[boardId]/_components/list-item.tsx
+++ b/app/(platform)/(dashboard)/board/[boardId]/_components/list-item.tsx
@@ -1,8 +1,12 @@
 "use client";
 
+import { fetcher } from "@/lib/fetcher";
 import { cn } from "@/lib/utils";
 import { ListWithCards } from "@/types";
+import { AppApiRoutes } from "@/util/appRoutes";
+import { User } from "@clerk/nextjs/server";
 import { Draggable, Droppable } from "@hello-pangea/dnd";
+import { useQuery } from "@tanstack/react-query";
 import { ElementRef, useRef, useState } from "react";
 import { CardForm } from "./card-form";
 import { CardItem } from "./card-item";
@@ -11,11 +15,15 @@ import { ListHeader } from "./list-header";
 interface ListItemProps {
   data: ListWithCards;
   index: number;
+  boardId: string;
 }
 
-export const ListItem = ({ data, index }: ListItemProps) => {
+export const ListItem = ({ data, boardId, index }: ListItemProps) => {
   const textareaRef = useRef<ElementRef<"textarea">>(null);
-
+  const { data: usersFromOrg } = useQuery<User[]>({
+    queryKey: ["organization", boardId],
+    queryFn: () => fetcher(AppApiRoutes.USERS_ORGANIZATION),
+  });
   const [isEditing, setIsEditing] = useState(false);
 
   const enableEditing = () => {
@@ -53,9 +61,19 @@ export const ListItem = ({ data, index }: ListItemProps) => {
                     data.cards.length > 0 ? "mt-2" : "mt-0"
                   )}
                 >
-                  {data.cards.map((card, index) => (
-                    <CardItem key={card.id} index={index} data={card} />
-                  ))}
+                  {data.cards.map((card, index) => {
+                    const assignedUser = usersFromOrg?.find(
+                      (user) => user.id === card.assignedTo
+                    );
+                    return (
+                      <CardItem
+                        key={card.id}
+                        index={index}
+                        data={card}
+                        user={assignedUser}
+                      />
+                    );
+                  })}
                   {provided.placeholder}
                 </ol>
               )}

--- a/app/(platform)/(dashboard)/organization/[organizationId]/boardOverview/page.tsx
+++ b/app/(platform)/(dashboard)/organization/[organizationId]/boardOverview/page.tsx
@@ -50,7 +50,12 @@ const boardOverviewPage = async () => {
         return (
           <div key={board.id} className="flex gap-2">
             <BoardCard boardTitle={board.title} />
-            <ListContainer boardId={board.id} data={sprintLists} hideAddList />
+            <ListContainer
+              boardId={board.id}
+              data={sprintLists}
+              hideAddList
+              dragMode="changeSprint"
+            />
           </div>
         );
       })}

--- a/app/(platform)/(dashboard)/organization/[organizationId]/boardOverview/page.tsx
+++ b/app/(platform)/(dashboard)/organization/[organizationId]/boardOverview/page.tsx
@@ -1,9 +1,59 @@
+import { db } from "@/lib/db";
+import AppRoutes from "@/util/appRoutes";
+import { auth } from "@clerk/nextjs/server";
+import { UsersRound } from "lucide-react";
+import { redirect } from "next/navigation";
+import { ListContainer } from "../../../board/[boardId]/_components/list-container";
+
 const boardOverviewPage = async () => {
+  const { orgId } = await auth();
+
+  if (!orgId) {
+    redirect(AppRoutes.SELECT_ORGANIZATION);
+  }
+
+  const boards = await db.board.findMany({
+    where: {
+      orgId,
+    },
+    include: {
+      lists: {
+        include: {
+          cards: {
+            orderBy: {
+              order: "asc",
+            },
+          },
+        },
+      },
+    },
+  });
+
   return (
-    <div className="flex flex-col space-y-4">
-      <h1>desenvolvimento</h1>
+    <div className="p-4 h-full overflow-x-auto space-y-2">
+      {boards.map((board) => (
+        <div key={board.id} className="flex gap-2">
+          <BoardCard boardTitle={board.title} />
+          <ListContainer boardId={board.id} data={board.lists} />
+        </div>
+      ))}
     </div>
   );
 };
 
 export default boardOverviewPage;
+
+interface BoardCardProps {
+  boardTitle: string;
+}
+
+const BoardCard = ({ boardTitle }: BoardCardProps) => {
+  return (
+    <div className="shrink-0 h-full w-[272px] select-none">
+      <div className="w-full rounded-md bg-[#f1f2f4] shadow-md p-2 flex gap-2 items-center">
+        <UsersRound className="h-4 w-4" />
+        {boardTitle}
+      </div>
+    </div>
+  );
+};

--- a/app/(platform)/(dashboard)/organization/[organizationId]/boardOverview/page.tsx
+++ b/app/(platform)/(dashboard)/organization/[organizationId]/boardOverview/page.tsx
@@ -1,5 +1,7 @@
 import { db } from "@/lib/db";
+import { ListWithCards } from "@/types";
 import AppRoutes from "@/util/appRoutes";
+import Sprints from "@/util/sprints";
 import { auth } from "@clerk/nextjs/server";
 import { UsersRound } from "lucide-react";
 import { redirect } from "next/navigation";
@@ -31,12 +33,27 @@ const boardOverviewPage = async () => {
 
   return (
     <div className="p-4 h-full overflow-x-auto space-y-2">
-      {boards.map((board) => (
-        <div key={board.id} className="flex gap-2">
-          <BoardCard boardTitle={board.title} />
-          <ListContainer boardId={board.id} data={board.lists} />
-        </div>
-      ))}
+      {boards.map((board) => {
+        const sprintLists: ListWithCards[] = Object.values(Sprints).map(
+          (sprint) => ({
+            title: `Sprint ${sprint}`,
+            boardId: board.id,
+            cards: board.lists
+              .flatMap((list) => list.cards)
+              .filter((card) => card.sprint === parseInt(sprint)),
+            id: sprint,
+            order: parseInt(sprint),
+            createdAt: new Date(),
+            updatedAt: new Date(),
+          })
+        );
+        return (
+          <div key={board.id} className="flex gap-2">
+            <BoardCard boardTitle={board.title} />
+            <ListContainer boardId={board.id} data={sprintLists} hideAddList />
+          </div>
+        );
+      })}
     </div>
   );
 };
@@ -49,7 +66,7 @@ interface BoardCardProps {
 
 const BoardCard = ({ boardTitle }: BoardCardProps) => {
   return (
-    <div className="shrink-0 h-full w-[272px] select-none">
+    <div className="shrink-0 h-full w-[272px] select-none mr-4">
       <div className="w-full rounded-md bg-[#f1f2f4] shadow-md p-2 flex gap-2 items-center">
         <UsersRound className="h-4 w-4" />
         {boardTitle}

--- a/app/(platform)/(dashboard)/organization/[organizationId]/boardOverview/page.tsx
+++ b/app/(platform)/(dashboard)/organization/[organizationId]/boardOverview/page.tsx
@@ -54,6 +54,7 @@ const boardOverviewPage = async () => {
               boardId={board.id}
               data={sprintLists}
               hideAddList
+              hideAddCard
               dragMode="changeSprint"
             />
           </div>

--- a/app/api/cards/[cardId]/route.ts
+++ b/app/api/cards/[cardId]/route.ts
@@ -28,6 +28,7 @@ export async function GET(
         list: {
           select: {
             title: true,
+            boardId: true,
           },
         },
       },

--- a/app/api/users/organization/route.ts
+++ b/app/api/users/organization/route.ts
@@ -1,7 +1,7 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
 import { NextResponse } from "next/server";
 
-export async function GET(req: Request) {
+export async function GET() {
   try {
     const { userId, orgId } = await auth();
 

--- a/app/api/users/organization/route.ts
+++ b/app/api/users/organization/route.ts
@@ -1,0 +1,25 @@
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { NextResponse } from "next/server";
+
+export async function GET(req: Request) {
+  try {
+    const { userId, orgId } = await auth();
+
+    if (!userId || !orgId) {
+      return new NextResponse("Unauthorized", { status: 401 });
+    }
+
+    const client = await clerkClient();
+
+    const paginatedResult = await client.users.getUserList({
+      organizationId: [orgId],
+      limit: 500, // TODO:change to paginate later
+    });
+    const usersFromOrg = paginatedResult.data;
+
+    return NextResponse.json(usersFromOrg);
+  } catch (error) {
+    console.error(error);
+    return new NextResponse("Internal error", { status: 500 });
+  }
+}

--- a/components/assigned-to-tag.tsx
+++ b/components/assigned-to-tag.tsx
@@ -56,7 +56,12 @@ interface AssignedToSelectProps {
   users?: User[];
 }
 
-const UserAvatar = ({ user }: { user: User }) => {
+interface UserAvatarProps {
+  user: User;
+  displayName?: boolean;
+}
+
+export const UserAvatar = ({ user, displayName = true }: UserAvatarProps) => {
   return (
     <div className="flex gap-2 justify-center items-center">
       <Image
@@ -66,7 +71,11 @@ const UserAvatar = ({ user }: { user: User }) => {
         height={24}
         className="self-center rounded-lg"
       />
-      {user.firstName} {user.lastName}
+      {displayName && (
+        <>
+          {user.firstName} {user.lastName}
+        </>
+      )}
     </div>
   );
 };

--- a/components/assigned-to-tag.tsx
+++ b/components/assigned-to-tag.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { updateCardAssignedTo } from "@/actions/update-card-assigned-to";
+import { useAction } from "@/hooks/use-action";
+import { fetcher } from "@/lib/fetcher";
+import { AppApiRoutes } from "@/util/appRoutes";
+import { User } from "@clerk/nextjs/server";
+import { Card } from "@prisma/client";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { User2 } from "lucide-react";
+import Image from "next/image";
+import { useParams } from "next/navigation";
+import { toast } from "sonner";
+import { Badge } from "./ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "./ui/select";
+
+interface AssignedToTagProps {
+  card: Card;
+}
+
+export const AssignedToTag = ({ card }: AssignedToTagProps) => {
+  const params = useParams();
+  const { data: usersFromOrg } = useQuery<User[]>({
+    queryKey: ["organization", params.boardId],
+    queryFn: () => fetcher(AppApiRoutes.USERS_ORGANIZATION),
+  });
+
+  const assignedUser = usersFromOrg?.find(
+    (user) => user.id === card.assignedTo
+  );
+
+  return (
+    <Badge variant="secondary">
+      <AssignedToSelect cardId={card.id} users={usersFromOrg}>
+        {!card.assignedTo || !assignedUser ? (
+          <User2 className="h-4 w-4" />
+        ) : (
+          <SelectValue placeholder={<UserAvatar user={assignedUser} />} />
+        )}
+      </AssignedToSelect>
+    </Badge>
+  );
+};
+
+interface AssignedToSelectProps {
+  children: React.ReactNode;
+  cardId: string;
+  users?: User[];
+}
+
+const UserAvatar = ({ user }: { user: User }) => {
+  return (
+    <div className="flex gap-2 justify-center items-center">
+      <Image
+        src={user.imageUrl}
+        alt={`${user.firstName} ${user.lastName} profile pic`}
+        width={24}
+        height={24}
+        className="self-center rounded-lg"
+      />
+      {user.firstName} {user.lastName}
+    </div>
+  );
+};
+
+const AssignedToSelect = ({
+  children,
+  cardId,
+  users,
+}: AssignedToSelectProps) => {
+  const queryClient = useQueryClient();
+  const params = useParams();
+
+  const { execute } = useAction(updateCardAssignedTo, {
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: ["card", data.id],
+      });
+      toast.success(`Assigned card"`);
+    },
+  });
+
+  const onChange = (e: string) => {
+    const boardId = params.boardId as string;
+    console.log("event", e);
+
+    execute({ id: cardId, boardId, assignedTo: e });
+  };
+
+  if (!users) return null;
+
+  return (
+    <Select onValueChange={onChange}>
+      <SelectTrigger minimal>{children}</SelectTrigger>
+      <SelectContent>
+        <SelectGroup>
+          <SelectLabel>Assigned To</SelectLabel>
+          {users.map((user) => (
+            <SelectItem key={user.id} value={user.id}>
+              <UserAvatar user={user} />
+            </SelectItem>
+          ))}
+        </SelectGroup>
+      </SelectContent>
+    </Select>
+  );
+};

--- a/components/assigned-to-tag.tsx
+++ b/components/assigned-to-tag.tsx
@@ -99,7 +99,6 @@ const AssignedToSelect = ({
 
   const onChange = (e: string) => {
     const boardId = params.boardId as string;
-    console.log("event", e);
 
     execute({ id: cardId, boardId, assignedTo: e });
   };

--- a/components/hint.tsx
+++ b/components/hint.tsx
@@ -10,16 +10,18 @@ interface HintProps {
   description: string;
   side?: "left" | "right" | "top" | "bottom";
   sideOffset?: number;
+  delayDuration?: number;
 }
 export const Hint = ({
   children,
   description,
   side = "bottom",
   sideOffset = 0,
+  delayDuration = 0,
 }: HintProps) => {
   return (
     <TooltipProvider>
-      <Tooltip delayDuration={0}>
+      <Tooltip delayDuration={delayDuration}>
         <TooltipTrigger>{children}</TooltipTrigger>
         <TooltipContent
           sideOffset={sideOffset}

--- a/components/modals/card-modal/header.tsx
+++ b/components/modals/card-modal/header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { updateCard } from "@/actions/update-card";
+import { AssignedToTag } from "@/components/assigned-to-tag";
 import { FormInput } from "@/components/form/form-input";
 import { SprintTag } from "@/components/sprint-tag";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -60,9 +61,12 @@ export const Header = ({ data }: HeaderProps) => {
           />
         </form>
         <div className="flex justify-between">
-          <p className="text-sm text-muted-foreground">
-            in list <span className="underline">{data.list.title}</span>
-          </p>
+          <>
+            <p className="text-sm text-muted-foreground">
+              in list <span className="underline">{data.list.title}</span>
+            </p>
+            <AssignedToTag card={data} />
+          </>
           <SprintTag sprintNumber={data.sprint} cardId={data.id} />
         </div>
       </div>

--- a/components/modals/card-modal/header.tsx
+++ b/components/modals/card-modal/header.tsx
@@ -67,7 +67,11 @@ export const Header = ({ data }: HeaderProps) => {
             </p>
             <AssignedToTag card={data} />
           </>
-          <SprintTag sprintNumber={data.sprint} cardId={data.id} />
+          <SprintTag
+            sprintNumber={data.sprint}
+            cardId={data.id}
+            boardId={data.list.boardId}
+          />
         </div>
       </div>
     </div>

--- a/components/sprint-tag.tsx
+++ b/components/sprint-tag.tsx
@@ -5,7 +5,6 @@ import { useAction } from "@/hooks/use-action";
 import Sprints from "@/util/sprints";
 import { useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
-import { useParams } from "next/navigation";
 import { toast } from "sonner";
 import { Badge } from "./ui/badge";
 import {
@@ -55,7 +54,6 @@ interface SprintSelectProps {
 
 const SprintSelect = ({ children, cardId, boardId }: SprintSelectProps) => {
   const queryClient = useQueryClient();
-  const params = useParams();
 
   const { execute } = useAction(updateCardSprint, {
     onSuccess: (data) => {

--- a/components/sprint-tag.tsx
+++ b/components/sprint-tag.tsx
@@ -2,6 +2,7 @@
 
 import { updateCardSprint } from "@/actions/update-card-sprint";
 import { useAction } from "@/hooks/use-action";
+import Sprints from "@/util/sprints";
 import { useQueryClient } from "@tanstack/react-query";
 import { Plus } from "lucide-react";
 import { useParams } from "next/navigation";
@@ -20,12 +21,17 @@ import {
 interface SprintTagProps {
   sprintNumber?: number | null;
   cardId: string;
+  boardId: string;
 }
 
-export const SprintTag = ({ sprintNumber, cardId }: SprintTagProps) => {
+export const SprintTag = ({
+  sprintNumber,
+  cardId,
+  boardId,
+}: SprintTagProps) => {
   return (
     <Badge variant="secondary">
-      <SprintSelect cardId={cardId}>
+      <SprintSelect cardId={cardId} boardId={boardId}>
         {!sprintNumber ? (
           <>
             Add to sprint <Plus className="ml-2 h-4 w-4" />
@@ -44,9 +50,10 @@ export const SprintTag = ({ sprintNumber, cardId }: SprintTagProps) => {
 interface SprintSelectProps {
   children: React.ReactNode;
   cardId: string;
+  boardId: string;
 }
 
-const SprintSelect = ({ children, cardId }: SprintSelectProps) => {
+const SprintSelect = ({ children, cardId, boardId }: SprintSelectProps) => {
   const queryClient = useQueryClient();
   const params = useParams();
 
@@ -61,8 +68,6 @@ const SprintSelect = ({ children, cardId }: SprintSelectProps) => {
   });
 
   const onChange = (e: string) => {
-    const boardId = params.boardId as string;
-
     const sprint = Number.parseInt(e);
 
     execute({ id: cardId, boardId, sprint });
@@ -74,11 +79,11 @@ const SprintSelect = ({ children, cardId }: SprintSelectProps) => {
       <SelectContent>
         <SelectGroup>
           <SelectLabel>Sprints</SelectLabel>
-          <SelectItem value="1">1</SelectItem>
-          <SelectItem value="2">2</SelectItem>
-          <SelectItem value="3">3</SelectItem>
-          <SelectItem value="4">4</SelectItem>
-          <SelectItem value="5">5</SelectItem>
+          {Object.values(Sprints).map((sprint) => (
+            <SelectItem key={sprint} value={sprint}>
+              {sprint}
+            </SelectItem>
+          ))}
         </SelectGroup>
       </SelectContent>
     </Select>

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@radix-ui/react-select": "^2.1.5",
         "@radix-ui/react-separator": "^1.1.1",
         "@radix-ui/react-slot": "^1.1.1",
-        "@radix-ui/react-tooltip": "^1.1.7",
+        "@radix-ui/react-tooltip": "^1.1.8",
         "@tanstack/react-query": "^5.64.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -1587,22 +1587,185 @@
       }
     },
     "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.7.tgz",
-      "integrity": "sha512-ss0s80BC0+g0+Zc53MvilcnTYSOi4mSuFWBPYPuTOFGjx+pUU+ZrmamMNwS56t8MTFlniA5ocjd4jYm/CdhbOg==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.8.tgz",
+      "integrity": "sha512-YAA2cu48EkJZdAMHC0dqo9kialOcRStbtiY4nJPaht7Ptrhcvpo+eDChaM6BIs8kL6a8Z5l5poiqLnXcNduOkA==",
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",
         "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-context": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.4",
+        "@radix-ui/react-dismissable-layer": "1.1.5",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-popper": "1.2.1",
-        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-popper": "1.2.2",
+        "@radix-ui/react-portal": "1.1.4",
         "@radix-ui/react-presence": "1.1.2",
-        "@radix-ui/react-primitive": "2.0.1",
-        "@radix-ui/react-slot": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-slot": "1.1.2",
         "@radix-ui/react-use-controllable-state": "1.1.0",
-        "@radix-ui/react-visually-hidden": "1.1.1"
+        "@radix-ui/react-visually-hidden": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.2.tgz",
+      "integrity": "sha512-G+KcpzXHq24iH0uGG/pF8LyzpFJYGD4RfLjCIBfGdSLXvjLHST31RUiRVrupIBMvIppMgSzQ6l66iAxl03tdlg==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.5.tgz",
+      "integrity": "sha512-E4TywXY6UsXNRhFrECa5HAvE5/4BFcGyfTyK36gP+pAW1ed7UTK4vKwdr53gAJYwqbfCWC6ATvJa3J3R/9+Qrg==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-popper": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.2.tgz",
+      "integrity": "sha512-Rvqc3nOpwseCyj/rgjlJDYAgyfw7OC1tTkKn2ivhaMGcYt8FSBlahHOZak2i3QwkRXUXgGgzeEe2RuqeEHuHgA==",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-layout-effect": "1.1.0",
+        "@radix-ui/react-use-rect": "1.1.0",
+        "@radix-ui/react-use-size": "1.1.0",
+        "@radix-ui/rect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.4.tgz",
+      "integrity": "sha512-sn2O9k1rPFYVyKd5LAJfo96JlSGVFpa1fS6UuBJfrZadudiw5tAmru+n1x7aMRQ84qDM71Zh1+SzK5QwU0tJfA==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-primitive": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.2.tgz",
+      "integrity": "sha512-Ec/0d38EIuvDF+GZjcMU/Ze6MxntVJYO/fRlCPhCaVUyPY9WTalHJw54tp9sXeJo3tlShWpy41vQRgLRGOuz+w==",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.1.2.tgz",
+      "integrity": "sha512-YAKxaiGsSQJ38VzKH86/BPRC4rh+b1Jpa+JneA5LRE7skmLPNAyeG8kPJj/oo4STLvlrs8vkf/iYyc3A5stYCQ==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.2.tgz",
+      "integrity": "sha512-1SzA4ns2M1aRlvxErqhLHsBHoS5eI5UUcI2awAMgGUp4LoaoWOKYmvqDY2s/tltuPkh3Yk77YF/r3IRj+Amx4Q==",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.0.2"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@radix-ui/react-select": "^2.1.5",
     "@radix-ui/react-separator": "^1.1.1",
     "@radix-ui/react-slot": "^1.1.1",
-    "@radix-ui/react-tooltip": "^1.1.7",
+    "@radix-ui/react-tooltip": "^1.1.8",
     "@tanstack/react-query": "^5.64.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,7 @@ model Card {
     order       Int
     description String? @db.Text
     sprint      Int?
+    assignedTo  String?
 
     listId String
     list   List   @relation(fields: [listId], references: [id], onDelete: Cascade)

--- a/util/appRoutes.ts
+++ b/util/appRoutes.ts
@@ -26,6 +26,8 @@ export const buildRoute = (
 export enum AppApiRoutes {
   BASE = "/api",
   CARDS = `${AppApiRoutes.BASE}/cards/:cardId`,
+  USERS = `${AppApiRoutes.BASE}/users`,
+  USERS_ORGANIZATION = `${AppApiRoutes.USERS}/organization`,
 }
 
 export default AppRoutes;

--- a/util/sprints.ts
+++ b/util/sprints.ts
@@ -1,0 +1,10 @@
+enum Sprints {
+  SPRINT1 = "1",
+  SPRINT2 = "2",
+  SPRINT3 = "3",
+  SPRINT4 = "4",
+  SPRINT5 = "5",
+  SPRINT6 = "6",
+}
+
+export default Sprints;


### PR DESCRIPTION
Created the foundation for the overview page.

The page displays multiple lists based on sprints, with each list containing the corresponding sprint’s cards. Drag and drop functionality allows moving cards between sprints, but dragging to another board is not yet supported.

Several new props have been added to enhance the lists component, allowing customization for different scenarios. These include options to disable list dragging, hide the "Add List" button, and hide the "Add Card" button.